### PR TITLE
Alterando forma de bater e finalizar o plantão

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -8,8 +8,8 @@ export const isLoginMember = () => {
   if(user) {
     if(user.member){
       if (user.member.id) {
-        return true; 
-       }
+        return true;
+      }
     }
 	}
   return false;

--- a/src/api/duty.js
+++ b/src/api/duty.js
@@ -3,7 +3,7 @@ import api from './api';
 const membersDuty = {
   create : data => api.post('/duties/register', data),
   list : jeId => api.get(`duties/${jeId}/today`),
-  update : () => api.put('/duties/finish'),
+  finish : data => api.put('/duties/finish', data),
   index : id => api.get(`duties/${id}`),
 };
 

--- a/src/api/duty.js
+++ b/src/api/duty.js
@@ -3,7 +3,7 @@ import api from './api';
 const membersDuty = {
   create : data => api.post('/duties/register', data),
   list : jeId => api.get(`duties/${jeId}/today`),
-  update : id => api.put(`/duties/${id}/finish`),
+  update : () => api.put('/duties/finish'),
   index : id => api.get(`duties/${id}`),
 };
 

--- a/src/components/duty/ModalFinishingDuty.js
+++ b/src/components/duty/ModalFinishingDuty.js
@@ -1,26 +1,45 @@
 import React, { useState } from 'react';
-import { Form, Input, Modal, Button, message } from 'antd';
+
+import { isLoginMember } from '../../api/auth';
+
+import { Form, Input, Modal, Button, message, Popconfirm } from 'antd';
 
 function ModalFinishingDuty(props) {
   const [visible, setVisible] = useState(false);
   const [loading, setLoading] = useState(false);
   const { getFieldDecorator } = props.form;
 
+  function verifyMemberLogged() {
+    if (props.member.duty.memberId === props.memberId) return true;
+    return false;
+  }
+
   function onSubmit(e) {
     e.preventDefault();
     props.form.validateFields((err, values) => {
+      setLoading(true);
       if (!err) {
-        setLoading(true);
+        values.member = props.member;
+        values.dutyId = props.dutyId;
+        values.id = props.member.duty.memberId;
         props.onSubmit(values);
-      } 
+        setLoading(false);
+        setVisible(false);
+      }
       else {
-          setLoading(false);
-          message.error("Senha incorreta, tente novamente...");
-        }
+        setLoading(false);
+        message.error("Senha incorreta, tente novamente...");
+      }
     });
   }
 
   return (
+    isLoginMember() ?
+    <Popconfirm title="Finalizar plantão?" onConfirm={onSubmit} disabled={!verifyMemberLogged()}>
+      <Button disabled={!verifyMemberLogged()} type="primary" >Encerrar</Button>
+    </Popconfirm> :
+    <>
+      <Button type="primary" onClick={() => setVisible(true)} >Encerrar</Button>
       <Modal
         destroyOnClose={true}
         visible={visible}
@@ -44,6 +63,8 @@ function ModalFinishingDuty(props) {
           </Form.Item>
         </Form>
       </Modal>
+    </>
   )
 }
-export default Form.create()(ModalFinishingDuty)
+
+export default Form.create()(ModalFinishingDuty);

--- a/src/components/duty/ModalFinishingDuty.js
+++ b/src/components/duty/ModalFinishingDuty.js
@@ -8,16 +8,15 @@ function ModalFinishingDuty(props) {
 
   function onSubmit(e) {
     e.preventDefault();
-    props.form.validateFields(async (err, values) => {
+    props.form.validateFields((err, values) => {
       if (!err) {
         setLoading(true);
-        try {
-          props.onSubmit(values);
-        } catch (error) {
+        props.onSubmit(values);
+      } 
+      else {
           setLoading(false);
-          message.error(error.response.data.msg);
+          message.error("Senha incorreta, tente novamente...");
         }
-      }
     });
   }
 

--- a/src/components/duty/ModalFinishingDuty.js
+++ b/src/components/duty/ModalFinishingDuty.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { Form, Input, Modal, Button, message } from 'antd';
+
+function ModalFinishingDuty(props) {
+  const [visible, setVisible] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const { getFieldDecorator } = props.form;
+
+  function onSubmit(e) {
+    e.preventDefault();
+    props.form.validateFields(async (err, values) => {
+      if (!err) {
+        setLoading(true);
+        try {
+          props.onSubmit(values);
+        } catch (error) {
+          setLoading(false);
+          message.error(error.response.data.msg);
+        }
+      }
+    });
+  }
+
+  return (
+      <Modal
+        destroyOnClose={true}
+        visible={visible}
+        title="Identificação de usuário"
+        onOk={onSubmit}
+        onCancel={() => setVisible(false)}
+        footer={[
+          <Button key="back" onClick={() => setVisible(false)}>
+            Cancelar
+          </Button>,
+          <Button key="submit" type="primary" loading={loading} onClick={onSubmit}>
+            Finalizar plantão
+          </Button>,
+        ]}
+      >
+        <Form>
+          <Form.Item>
+            {getFieldDecorator('password', {
+              rules: [{ required: true, message: 'Please input your password!' }],
+            })(<Input.Password placeholder='senha' />)}
+          </Form.Item>
+        </Form>
+      </Modal>
+  )
+}
+export default Form.create()(ModalFinishingDuty)

--- a/src/components/duty/ModalOnDuty.js
+++ b/src/components/duty/ModalOnDuty.js
@@ -15,7 +15,7 @@ function ModalOnDuty(props) {
                 setLoading(true);
                 try {
                     const response = await membersDutyApi.create(values);
-                    if (response.status === 201) {
+                    if (response.status === 200) {
                         setLoading(false);
                         setVisible(false);
                         props.setNewDuty(response.data.duty.id);

--- a/src/components/duty/ModalOnDuty.js
+++ b/src/components/duty/ModalOnDuty.js
@@ -1,65 +1,68 @@
 import React, { useState } from 'react';
-import { Form, Input, Modal, Button, message } from 'antd';
-import { membersDutyApi }  from '../../api';
+import { Form, Input, Modal, Button, message, Popconfirm } from 'antd';
+import { membersDutyApi } from '../../api';
+import { isLoginMember } from '../../api/auth';
 
-function ModalOnDuty( props) {
+function ModalOnDuty(props) {
     const [visible, setVisible] = useState(false);
     const [loading, setLoading] = useState(false);
     const { getFieldDecorator } = props.form;
-    
-    function onSubmit (e) {
+
+    function onSubmit(e) {
         e.preventDefault();
-        props.form.validateFields(async(err, values) => {
+        props.form.validateFields(async (err, values) => {
             if (!err) {
                 setLoading(true);
                 try {
-                  const response = await membersDutyApi.create(values);
-                  if(response.status === 201) {
+                    const response = await membersDutyApi.create(values);
+                    if (response.status === 201) {
+                        setLoading(false);
+                        setVisible(false);
+                        props.setNewDuty(response.data.duty.id);
+                        message.success('Plantão iniciado!');
+                    }
+                } catch (error) {
                     setLoading(false);
-                    setVisible(false);
-                    props.setNewDuty(response.data.duty.id);
-                    message.success('Plantão iniciado!');
-                  }
-                } catch(error) {
-                  setLoading(false);
-                  message.error(error.response.data.msg);
+                    message.error(error.response.data.msg);
                 }
-              }
+            }
         });
     }
-    
+
     return (
-        <>
-            <Button disabled={props.disabled} type="primary" onClick={() => setVisible(true)} >Iniciar</Button>
-            <Modal
-                destroyOnClose={true}
-                visible={visible}
-                title="Identificação de usuário"
-                onOk={onSubmit}
-                onCancel={() => setVisible(false)}
-                footer={[
-                    <Button key="back" onClick={() => setVisible(false)}>
-                        Cancelar
-                   </Button>,
-                    <Button key="submit" type="primary" loading={loading} onClick={onSubmit}>
-                        Iniciar plantão
-                   </Button>,
-                ]}
-            >
-                <Form>
-                    <Form.Item>
-                        {getFieldDecorator('email', {
-                            rules: [{ required: true, message: 'Please input your email!' }],
-                        })(<Input placeholder='email'/>)}
-                    </Form.Item>
-                    <Form.Item>
-                        {getFieldDecorator('password', {
-                            rules: [{ required: true, message: 'Please input your password!' }],
-                        })(<Input.Password placeholder='senha'/>)}
-                    </Form.Item>
-                </Form>
-            </Modal>
-        </>
+        isLoginMember() ?
+            <Popconfirm title="Deseja iniciar um plantão?" onConfirm={onSubmit}><Button disabled={props.disabled} type="primary" >Iniciar</Button></Popconfirm>:
+            <>
+                <Button disabled={props.disabled} type="primary" onClick={() => setVisible(true)} >Iniciar</Button>
+                <Modal
+                    destroyOnClose={true}
+                    visible={visible}
+                    title="Identificação de usuário"
+                    onOk={onSubmit}
+                    onCancel={() => setVisible(false)}
+                    footer={[
+                        <Button key="back" onClick={() => setVisible(false)}>
+                            Cancelar
+                        </Button>,
+                        <Button key="submit" type="primary" loading={loading} onClick={onSubmit}>
+                            Iniciar plantão
+                        </Button>,
+                    ]}
+                >
+                    <Form>
+                        <Form.Item>
+                            {getFieldDecorator('email', {
+                                rules: [{ required: true, message: 'Please input your email!' }],
+                            })(<Input placeholder='email' />)}
+                        </Form.Item>
+                        <Form.Item>
+                            {getFieldDecorator('password', {
+                                rules: [{ required: true, message: 'Please input your password!' }],
+                            })(<Input.Password placeholder='senha' />)}
+                        </Form.Item>
+                    </Form>
+                </Modal>
+            </>
     )
 }
 export default Form.create()(ModalOnDuty)

--- a/src/components/duty/ModalOnDuty.js
+++ b/src/components/duty/ModalOnDuty.js
@@ -31,9 +31,11 @@ function ModalOnDuty(props) {
 
     return (
         isLoginMember() ?
-            <Popconfirm title="Deseja iniciar um plantão?" onConfirm={onSubmit}><Button disabled={props.disabled} type="primary" >Iniciar</Button></Popconfirm>:
+            <Popconfirm title="Deseja iniciar um plantão?" onConfirm={onSubmit}>
+                <Button type="primary" >Iniciar</Button>
+            </Popconfirm> :
             <>
-                <Button disabled={props.disabled} type="primary" onClick={() => setVisible(true)} >Iniciar</Button>
+                <Button type="primary" onClick={() => setVisible(true)} >Iniciar</Button>
                 <Modal
                     destroyOnClose={true}
                     visible={visible}
@@ -65,4 +67,5 @@ function ModalOnDuty(props) {
             </>
     )
 }
+
 export default Form.create()(ModalOnDuty)

--- a/src/views/dashboard/duty/Duty.js
+++ b/src/views/dashboard/duty/Duty.js
@@ -11,9 +11,11 @@ import { Container, Title, Content } from '../team/styles/team'
 import { DutyControllerButtons, DaysDuties } from './styles/duty';
 
 import { membersDutyApi } from '../../../api'
+import { isLoginMember } from '../../../api/auth';
 
 import user from '../../../assets/user.png';
 import ModalOnDuty from '../../../components/duty/ModalOnDuty'
+import ModalFinishingDuty from '../../../components/duty/ModalFinishingDuty';
 
 function Duty({ je }) {
   const apiURL = 'https://backend-dvora.herokuapp.com/files/member';
@@ -76,7 +78,6 @@ function Duty({ je }) {
     }
   }
 
-
   function handleChange(sorter) {
     setSortedInfo(sorter);
   };
@@ -110,9 +111,12 @@ function Duty({ je }) {
         },
         {
           title: 'Finalizar plantão',
-          dataIndex: 'duty.id',
+          dataIndex: 'duty.memberId',
           render: (text, record) => record.finishTime === null ?
-            <Popconfirm title="Finalizar plantão?" onConfirm={() => handleFinished(text, record)}>
+            <Popconfirm title="Finalizar plantão?" onConfirm={
+              isLoginMember() ?
+                handleFinished(text, record) :
+                <ModalFinishingDuty onSubmit={handleFinished} />}>
               <a>Encerrar</a>
             </Popconfirm>
             :

--- a/src/views/dashboard/duty/Duty.js
+++ b/src/views/dashboard/duty/Duty.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
-
 import { useHistory } from 'react-router-dom';
 
 import { Table, Popconfirm, message } from 'antd';
@@ -31,6 +30,7 @@ function Duty({ je }) {
     }
     return number;
   }
+
   function formatTime(time) {
     const currentdate = new Date(time);
     let h = addZero(currentdate.getHours());
@@ -60,7 +60,7 @@ function Duty({ je }) {
 
   async function handleFinished(dutyId, member) {
     try {
-      const response = await membersDutyApi.update(dutyId);
+      const response = await membersDutyApi.finish(dutyId);
       if (response.status === 200) {
         member.finishTime = formatTime(response.data.updatedAt);
         setMemberOnDuty([...memberOnDuty]);
@@ -71,7 +71,6 @@ function Duty({ je }) {
             dutyId,
           }
         });
-
       }
     } catch (error) {
       message.error(error.response.data.msg);
@@ -118,8 +117,7 @@ function Duty({ je }) {
                 handleFinished(text, record) :
                 <ModalFinishingDuty onSubmit={handleFinished} />}>
               <a>Encerrar</a>
-            </Popconfirm>
-            :
+            </Popconfirm> :
             <span>CONCLUÍDO!</span>
         },
       ]


### PR DESCRIPTION
PR relacionada a issue  #59.

- Agora, quando uma EJ estiver logada, na hora de bater um plantão, é requisitado uma autenticação do membro por meio de email e senha; na hora de finalizar, é requisitado somente a senha.
- Quando um membro estiver logado, não há nenhuma requisição.
- Membros não podem finalizar o plantão de outros membros por sua conta.